### PR TITLE
Add Qspectre flag for compile options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ ENDIF()
 
 IF (WIN32 AND MSVC)
   set (CMAKE_CXX_FLAGS " -DNDEBUG")
-  add_compile_options("/O2" "/W4" "/GS" "/Gy" "/guard:cf" "/Gm-" "/Zc:inline" "/fp:precise" "/GF" "/EHsc" "/ZH:SHA_256")
+  add_compile_options("/O2" "/W4" "/GS" "/Gy" "/guard:cf" "/Gm-" "/Zc:inline" "/fp:precise" "/GF" "/EHsc" "/ZH:SHA_256" "/Qspectre")
   add_compile_options("$<$<CONFIG:Debug>:/Od>")
   add_compile_options("$<$<NOT:$<CONFIG:Debug>>:/GL>")
   add_compile_options("$<$<NOT:$<CONFIG:Debug>>:/Ob2>")


### PR DESCRIPTION
Enable the /Qspectre flag as compile option as mitigations for speculative execution side-channel attack (Spectre) vulnerabilities.